### PR TITLE
ASM-2067 modified the module to take macaddress as the title/name of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ Normal interface - VLAN - static (minimal):
       netmask   => '255.255.255.0',
     }
 
+Using mac address instead of interface name - find interface by its macaddress and modify its configuration (supported for network::if::static and network::bond::slave resources only at the moment):
+
+    network::if::static { 'fe:fe:fe:aa:aa:aa':
+      ensure       => 'up',
+      ipaddress    => '1.2.3.6',
+      netmask      => '255.255.255.0',
+      gateway      => '1.2.3.1',
+    }
+
 Notes
 -----
 

--- a/lib/puppet/parser/functions/count_configured_interfaces.rb
+++ b/lib/puppet/parser/functions/count_configured_interfaces.rb
@@ -1,0 +1,8 @@
+module Puppet::Parser::Functions
+  newfunction(:count_configured_interfaces, :type => :rvalue) do |args|
+    macaddr = args[0]
+    interfaces = lookupvar("interfaces")
+
+    interfaces.split(",").count { |ifn| lookupvar("macaddress_#{ifn}") =~ /^#{macaddr}$/ }
+  end
+end

--- a/lib/puppet/parser/functions/map_macaddr_to_interface.rb
+++ b/lib/puppet/parser/functions/map_macaddr_to_interface.rb
@@ -1,0 +1,8 @@
+module Puppet::Parser::Functions
+  newfunction(:map_macaddr_to_interface, :type => :rvalue) do |args|
+    macaddr = args[0]
+    interfaces = lookupvar("interfaces")
+
+    interfaces.split(",").find { |ifn| lookupvar("macaddress_#{ifn}") =~ /^#{macaddr}$/ }
+  end
+end

--- a/manifests/bond/slave.pp
+++ b/manifests/bond/slave.pp
@@ -43,16 +43,29 @@ define network::bond::slave (
 
   include '::network'
 
-  $interface = $name
-
-  file { "ifcfg-${interface}":
-    ensure  => 'present',
-    mode    => '0644',
-    owner   => 'root',
-    group   => 'root',
-    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
-    content => template('network/ifcfg-bond.erb'),
-    before  => File["ifcfg-${master}"],
-    notify  => Service['network'],
+  if is_mac_address($name){
+    $interface = map_macaddr_to_interface($name)
+    if !$interface {
+      fail('Could not find the interface name for the given macaddress...')
+    }
+  } else {
+    $interface = $name
   }
+
+  $already_configured = $master in split($::interfaces, ',')
+
+  if !$already_configured {
+
+    file { "ifcfg-${interface}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+      content => template('network/ifcfg-bond.erb'),
+      before  => File["ifcfg-${master}"],
+      notify  => Service['network'],
+    }
+  }
+
 } # define network::bond::slave

--- a/manifests/bond/static.pp
+++ b/manifests/bond/static.pp
@@ -37,8 +37,9 @@
 #
 define network::bond::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
+  $vlanId = undef,
   $gateway = undef,
   $mtu = undef,
   $ethtool_opts = undef,
@@ -50,13 +51,15 @@ define network::bond::static (
   $ipv6peerdns = false,
   $dns1 = undef,
   $dns2 = undef,
-  $domain = undef
+  $domain = undef,
 ) {
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }
@@ -64,62 +67,28 @@ define network::bond::static (
   validate_bool($ipv6init)
   validate_bool($ipv6peerdns)
 
+  $already_configured = $title in split($::interfaces, ',')
 
-  network_if_base { $title:
-    ensure       => $ensure,
-    ipaddress    => $ipaddress,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    macaddress   => '',
-    bootproto    => 'none',
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    bonding_opts => $bonding_opts,
-    peerdns      => $peerdns,
-    ipv6init     => $ipv6init,
-    ipv6address  => $ipv6address,
-    ipv6peerdns  => $ipv6peerdns,
-    ipv6gateway  => $ipv6gateway,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
-  }
-
-  # Only install "alias bondN bonding" on old OSs that support
-  # /etc/modprobe.conf.
-  case $::operatingsystem {
-    /^(RedHat|CentOS|OEL|OracleLinux|SLC|Scientific)$/: {
-      case $::operatingsystemrelease {
-        /^[45]/: {
-          augeas { "modprobe.conf_${title}":
-            context => '/files/etc/modprobe.conf',
-            changes => [
-              "set alias[last()+1] ${title}",
-              'set alias[last()]/modulename bonding',
-            ],
-            onlyif  => "match alias[*][. = '${title}'] size == 0",
-            before  => Network_if_base[$title],
-          }
-        }
-        default: {}
-      }
+  if !$already_configured {
+    network_if_base { $title:
+      ensure       => $ensure,
+      ipaddress    => $ipaddress,
+      netmask      => $netmask,
+      gateway      => $gateway,
+      vlanId       => $vlanId,
+      macaddress   => '',
+      bootproto    => 'none',
+      mtu          => $mtu,
+      ethtool_opts => $ethtool_opts,
+      bonding_opts => $bonding_opts,
+      peerdns      => $peerdns,
+      ipv6init     => $ipv6init,
+      ipv6address  => $ipv6address,
+      ipv6peerdns  => $ipv6peerdns,
+      ipv6gateway  => $ipv6gateway,
+      dns1         => $dns1,
+      dns2         => $dns2,
+      domain       => $domain,
     }
-    'Fedora': {
-      case $::operatingsystemrelease {
-        /^(1|2|3|4|5|6|7|8|9|10|11)$/: {
-          augeas { "modprobe.conf_${title}":
-            context => '/files/etc/modprobe.conf',
-            changes => [
-              "set alias[last()+1] ${title}",
-              'set alias[last()]/modulename bonding',
-            ],
-            onlyif  => "match alias[*][. = '${title}'] size == 0",
-            before  => Network_if_base[$title],
-          }
-        }
-        default: {}
-      }
-    }
-    default: {}
   }
 } # define network::bond::static

--- a/manifests/bond/vlan.pp
+++ b/manifests/bond/vlan.pp
@@ -1,0 +1,65 @@
+# == Definition: network::bond::vlan
+#
+define network::bond::vlan (
+  $ensure,
+  $bootproto = 'none',
+  $ipaddress,
+  $netmask,
+  $vlanId,
+  $gateway,
+  $macaddress = '',
+  $mtu = undef,
+  $ethtool_opts = undef,
+  $bonding_opts = 'miimon=100',
+  $peerdns = false,
+  $ipv6init = false,
+  $ipv6address = undef,
+  $ipv6gateway = undef,
+  $ipv6peerdns = false,
+  $dns1 = undef,
+  $dns2 = undef,
+  $domain = undef
+) {
+
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+
+  if ! $vlanId { fail("vlanId must be passed for this resource type!") }
+  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipv6address {
+    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
+  }
+  validate_bool($ipv6init)
+  validate_bool($ipv6peerdns)
+
+  $onboot = $ensure ? {
+    'up'    => 'yes',
+    'down'  => 'no',
+    default => undef,
+  }
+
+  $interface = $name
+
+  #include '::network'
+
+  $already_configured = $name in split($::interfaces, ',')
+
+  if !$already_configured {
+    exec { "/bin/echo 'alias ifcfg-${interface} bonding' >> /etc/modprobe.d/bonding.conf":
+    }->
+    exec { "reload modprobe after ${interface} is added to bonding module config":
+      command => '/sbin/modprobe -r bonding; /sbin/modprobe bonding',
+    }->
+    file { "ifcfg-${interface}.${vlanId}}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}.${vlanId}",
+      content => template('network/ifcfg-eth.erb'),
+      notify => Service['network'],
+    }
+  }
+
+
+} # define network::bond::vlan

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -59,15 +59,16 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 class network::global (
-  $hostname       = undef,
-  $gateway        = undef,
-  $gatewaydev     = undef,
-  $ipv6gateway    = undef,
-  $ipv6defaultdev = undef,
-  $nisdomain      = undef,
-  $vlan           = undef,
-  $ipv6networking = false,
-  $nozeroconf     = undef
+  $hostname              = undef,
+  $gateway               = undef,
+  $gatewaydev            = undef,
+  $gatewaydev_macaddress = undef,
+  $ipv6gateway           = undef,
+  $ipv6defaultdev        = undef,
+  $nisdomain             = undef,
+  $vlan                  = undef,
+  $ipv6networking        = false,
+  $nozeroconf            = undef
 ) {
   # Validate our data
   if $gateway {
@@ -76,6 +77,9 @@ class network::global (
   if $ipv6gateway {
     if ! is_ip_address($ipv6gateway) { fail("${ipv6gateway} is not an IPv6 address.") }
   }
+  if $gatewaydev_macaddress {
+    if ! is_mac_address($gatewaydev_macaddress) { fail("${gatewaydev_macaddress} is not a valid mac address.") }
+  }
 
   validate_bool($ipv6networking)
 
@@ -83,6 +87,14 @@ class network::global (
   if $vlan {
     $states = [ '^yes$', '^no$' ]
     validate_re($vlan, $states, '$vlan must be either "yes" or "no".')
+  }
+
+  # Set the gateway device if its mac address is given instead
+  if is_mac_address($gatewaydev_macaddress){
+    $gatewaydev_from_mac = map_macaddr_to_interface(gatewaydev_macaddress)
+    if !$gatewaydev_from_mac {
+      fail('Could not find the gateway device name for the given macaddress...')
+    }
   }
 
   validate_bool($ipv6networking)

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -50,8 +50,8 @@
 #
 define network::if::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
   $gateway = undef,
   $ipv6address = undef,
   $ipv6init = false,
@@ -70,7 +70,9 @@ define network::if::static (
   $scope = undef
 ) {
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }
@@ -89,26 +91,29 @@ define network::if::static (
   validate_bool($peerdns)
   validate_bool($ipv6peerdns)
 
-  network_if_base { $title:
-    ensure       => $ensure,
-    ipv6init     => $ipv6init,
-    ipaddress    => $ipaddress,
-    ipv6address  => $ipv6address,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    ipv6gateway  => $ipv6gateway,
-    ipv6autoconf => $ipv6autoconf,
-    macaddress   => $macaddy,
-    bootproto    => 'none',
-    userctl      => $userctl,
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    peerdns      => $peerdns,
-    ipv6peerdns  => $ipv6peerdns,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
-    linkdelay    => $linkdelay,
-    scope        => $scope,
+  $num_configured_interfaces = count_configured_interfaces($name)
+  if $num_configured_interfaces < 2 {
+    network_if_base { $title:
+      ensure       => $ensure,
+      ipv6init     => $ipv6init,
+      ipaddress    => $ipaddress,
+      ipv6address  => $ipv6address,
+      netmask      => $netmask,
+      gateway      => $gateway,
+      ipv6gateway  => $ipv6gateway,
+      ipv6autoconf => $ipv6autoconf,
+      macaddress   => $macaddy,
+      bootproto    => 'none',
+      userctl      => $userctl,
+      mtu          => $mtu,
+      ethtool_opts => $ethtool_opts,
+      peerdns      => $peerdns,
+      ipv6peerdns  => $ipv6peerdns,
+      dns1         => $dns1,
+      dns2         => $dns2,
+      domain       => $domain,
+      linkdelay    => $linkdelay,
+      scope        => $scope,
+    }
   }
 } # define network::if::static

--- a/manifests/if/vlan.pp
+++ b/manifests/if/vlan.pp
@@ -1,0 +1,58 @@
+define network::if::vlan (
+  $ensure,
+  $vlanId,
+  $ipaddress,
+  $netmask,
+  $macaddress      = undef,
+  $gateway         = undef,
+  $bootproto       = 'none',
+  $userctl         = false,
+  $mtu             = undef,
+  $ethtool_opts    = undef,
+  $peerdns         = false,
+  $ipv6peerdns     = false,
+  $dns1            = undef,
+  $dns2            = undef,
+  $domain          = undef,
+  $linkdelay       = undef,
+  $scope           = undef,
+) {
+# Validate data
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
+  if $ipv6address {
+    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
+  }
+
+  if is_mac_address($name){
+    $interface = map_macaddr_to_interface($name)
+    if !$interface {
+      fail('Could not find the interface name for the given macaddress...')
+    }
+  } else {
+    $interface = $name
+  }
+
+  $onboot = $ensure ? {
+    'up'    => 'yes',
+    'down'  => 'no',
+    default => undef,
+  }
+
+  $num_configured_interfaces = count_configured_interfaces($name)
+
+  if $num_configured_interfaces < 2 {
+    file { "ifcfg-${interface}.${vlanId}}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}.${vlanId}",
+      content => template('network/ifcfg-eth.erb'),
+    }
+  }
+} # define network::if::vlan

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,11 +23,11 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 class network {
-  # Only run on RedHat derived systems.
+# Only run on RedHat derived systems.
   case $::osfamily {
     'RedHat': { }
     default: {
-      fail('This network module only supports RedHat-based systems.')
+    fail('This network module only supports RedHat-based systems.')
     }
   }
 
@@ -35,8 +35,9 @@ class network {
     ensure     => 'running',
     enable     => true,
     hasrestart => true,
-    hasstatus  => true,
+    hasstatus  => true
   }
+
 } # class network
 
 # == Definition: network_if_base
@@ -96,9 +97,10 @@ class network {
 #
 define network_if_base (
   $ensure,
-  $ipaddress,
-  $netmask,
-  $macaddress,
+  $ipaddress       = undef,
+  $netmask         = undef,
+  $macaddress      = undef,
+  $vlanId          = undef,
   $gateway         = undef,
   $ipv6address     = undef,
   $ipv6gateway     = undef,
@@ -111,6 +113,7 @@ define network_if_base (
   $ethtool_opts    = undef,
   $bonding_opts    = undef,
   $isalias         = false,
+  $isethernet      = true,
   $peerdns         = false,
   $ipv6peerdns     = false,
   $dns1            = undef,
@@ -120,9 +123,9 @@ define network_if_base (
   $linkdelay       = undef,
   $scope           = undef,
   $linkdelay       = undef,
-  $check_link_down = false
+  $check_link_down = false,
 ) {
-  # Validate our booleans
+# Validate our booleans
   validate_bool($userctl)
   validate_bool($isalias)
   validate_bool($peerdns)
@@ -130,15 +133,22 @@ define network_if_base (
   validate_bool($ipv6autoconf)
   validate_bool($ipv6peerdns)
   validate_bool($check_link_down)
-  # Validate our regular expressions
+# Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
 
   include '::network'
 
-  $interface = $name
+  if is_mac_address($name){
+    $interface = map_macaddr_to_interface($name)
+    if !$interface {
+      fail('Could not find the interface name for the given macaddress...')
+    }
+  } else {
+    $interface = $name
+  }
 
-  # Deal with the case where $dns2 is non-empty and $dns1 is empty.
+# Deal with the case where $dns2 is non-empty and $dns1 is empty.
   if $dns2 {
     if !$dns1 {
       $dns1_real = $dns2
@@ -168,13 +178,25 @@ define network_if_base (
     $iftemplate = template('network/ifcfg-eth.erb')
   }
 
-  file { "ifcfg-${interface}":
-    ensure  => 'present',
-    mode    => '0644',
-    owner   => 'root',
-    group   => 'root',
-    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
-    content => $iftemplate,
-    notify  => Service['network'],
+  if $vlanId {
+    file { "ifcfg-${interface}.${vlanId}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+      content => $iftemplate,
+      notify => Service['network'],
+    }
+  } else {
+    file { "ifcfg-${interface}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+      content => $iftemplate,
+      notify => Service['network'],
+    }
   }
 } # define network_if_base

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -1,13 +1,17 @@
 ###
 ### File managed by Puppet
 ###
-DEVICE=<%= @interface %>
 BOOTPROTO=<%= @bootproto %>
 <% if @macaddress and @macaddress != '' %>HWADDR=<%= @macaddress %>
 <% end -%>
 ONBOOT=<%= @onboot %>
 HOTPLUG=<%= @onboot %>
-TYPE=Ethernet
+<% if @isethernet %>TYPE=Ethernet<% end -%>
+<% if @vlanId and @vlanId != '' %>VLAN=yes
+DEVICE=<%= @interface %>.<%= @vlanId %>
+<% else %>
+DEVICE=<%= @interface %>
+<% end -%>
 <% if @ipaddress and @ipaddress != '' %>IPADDR=<%= @ipaddress %>
 <% end -%>
 <% if @netmask and @netmask != '' %>NETMASK=<%= @netmask %>

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -15,6 +15,7 @@ NETWORKING=yes
 <% if @gateway %>GATEWAY=<%= @gateway %>
 <% end -%>
 <% if @gatewaydev %>GATEWAYDEV=<%= @gatewaydev %>
+<% elsif @gatewaydev_from_mac %>GATEWAYDEV=<%= @gatewaydev_from_mac %>
 <% end -%>
 <% if @nisdomain %>NISDOMAIN=<%= @nisdomain %>
 <% end -%>


### PR DESCRIPTION
…the resource instead of requiring the interface name

instead of creating new fact and waiting for the second puppet agent run, inline_template function is used to do fact fetching and manipulation

clean up files that are no longer needed

final modifications done

modification to handle the gatewaydevice by macaddress

modified the checking already configured network settings more intuitive

additional bug fixes and prevention from misconfigurations

modified the module to take macaddress as the title/name of the resource instead of requiring the interface name

instead of creating new fact and waiting for the second puppet agent run, inline_template function is used to do fact fetching and manipulation

clean up files that are no longer needed

final modifications done

modification to handle the gatewaydevice by macaddress

modified the checking already configured network settings more intuitive

additional bug fixes and prevention from misconfigurations

regex updates