### PR TITLE
ASM-3012 - added support for Linux VM post OS processor

### DIFF
--- a/lib/puppet/parser/functions/get_seq_interface.rb
+++ b/lib/puppet/parser/functions/get_seq_interface.rb
@@ -1,0 +1,8 @@
+module Puppet::Parser::Functions
+  newfunction(:get_seq_interface, :type => :rvalue) do |args|
+    seq = args[0]
+    interfaces = lookupvar("interfaces")
+
+    interfaces.split(",").reject { |ifn| ifn == "lo" }.sort[seq]
+  end
+end

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -77,7 +77,7 @@ define network::if::static (
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }
 
-  if ! is_mac_address($macaddress) {
+  if (! is_mac_address($macaddress)) and (type($name) != "integer") {
     # Strip off any tailing VLAN (ie eth5.90 -> eth5).
     $title_clean = regsubst($title,'^(\w+)\.\d+$','\1')
     $macaddy = getvar("::macaddress_${title_clean}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,9 @@ define network_if_base (
 
   include '::network'
 
-  if is_mac_address($name){
+  if (type($name) == "integer") {
+    $interface = get_seq_interface($name)
+  } elsif is_mac_address($name) {
     $interface = map_macaddr_to_interface($name)
     if !$interface {
       fail('Could not find the interface name for the given macaddress...')
@@ -147,6 +149,7 @@ define network_if_base (
   } else {
     $interface = $name
   }
+
 
 # Deal with the case where $dns2 is non-empty and $dns1 is empty.
   if $dns2 {


### PR DESCRIPTION
modified puppet network module to take integer as the network resource title; the integer represents the sequence of the VM network adapter

modified the static.pp to ignore integer name/title