### PR TITLE
ASM-2067 updated parser function that gets interface name based on the macaddress with explicit caseignore

### DIFF
--- a/lib/puppet/parser/functions/map_macaddr_to_interface.rb
+++ b/lib/puppet/parser/functions/map_macaddr_to_interface.rb
@@ -3,6 +3,6 @@ module Puppet::Parser::Functions
     macaddr = args[0]
     interfaces = lookupvar("interfaces")
 
-    interfaces.split(",").find { |ifn| lookupvar("macaddress_#{ifn}") =~ /^#{macaddr}$/ }
+    interfaces.split(",").find { |ifn| lookupvar("macaddress_#{ifn}") =~ /^(?i)#{macaddr}$/ }
   end
 end


### PR DESCRIPTION
updated parser function that gets interface name based on the macaddress with explicit caseignore