### PR TITLE
ASM-6004 modified the network::if::vlan manifest to allow undef valuefor static NIC related options

### DIFF
--- a/manifests/if/vlan.pp
+++ b/manifests/if/vlan.pp
@@ -1,8 +1,8 @@
 define network::if::vlan (
   $ensure,
-  $vlanId,
-  $ipaddress,
-  $netmask,
+  $vlanId          = undef,
+  $ipaddress       = undef,
+  $netmask         = undef,
   $macaddress      = undef,
   $gateway         = undef,
   $bootproto       = 'none',


### PR DESCRIPTION
ASM-6004 modified the network::if::vlan manifest to allow undef valuefor static NIC related options