### PR TITLE
ASM-6089 added network::pxe_cleanup manifest

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -67,6 +67,7 @@ class network::global (
   $ipv6defaultdev        = undef,
   $nisdomain             = undef,
   $vlan                  = undef,
+  $vlanId                = undef,
   $ipv6networking        = false,
   $nozeroconf            = undef
 ) {
@@ -92,6 +93,11 @@ class network::global (
   # Set the gateway device if its mac address is given instead
   if is_mac_address($gatewaydev_macaddress){
     $gatewaydev_from_mac = map_macaddr_to_interface($gatewaydev_macaddress)
+    if $vlanId {
+      $gatewaydev_from_mac_final = "${gatewaydev_from_mac}.${$vlanId}"
+    } else {
+      $gatewaydev_from_mac_final = $gatewaydev_from_mac
+    }
     if !$gatewaydev_from_mac {
       fail('Could not find the gateway device name for the given macaddress...')
     }

--- a/manifests/pxe_cleanup.pp
+++ b/manifests/pxe_cleanup.pp
@@ -1,0 +1,28 @@
+define network::pxe_cleanup (
+  $ensure,
+  $bootproto       = 'dhcp',
+  $onboot          = "no"
+) {
+  $states = [ '^clean$', '^ignore$' ]
+  validate_re($ensure, $states, '$ensure must be either "clean" or "ignore".')
+
+  if is_mac_address($name) {
+    $interface = map_macaddr_to_interface($name)
+    if !$interface {
+      fail('Could not find the interface name for the given macaddress...')
+    }
+    $macaddress = $name
+  } else {
+    fail('Resource name for network::pxe_cleanup must be the MAC address of the target port/partition!')
+  }
+
+  file { "ifcfg-${interface}":
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+    content => template("network/ifcfg-eth.erb"),
+    notify => Service['network']
+  }
+} # define network::pxe_cleanup

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -15,7 +15,7 @@ NETWORKING=yes
 <% if @gateway %>GATEWAY=<%= @gateway %>
 <% end -%>
 <% if @gatewaydev %>GATEWAYDEV=<%= @gatewaydev %>
-<% elsif @gatewaydev_from_mac %>GATEWAYDEV=<%= @gatewaydev_from_mac %>
+<% elsif @gatewaydev_from_mac_final %>GATEWAYDEV=<%= @gatewaydev_from_mac_final %>
 <% end -%>
 <% if @nisdomain %>NISDOMAIN=<%= @nisdomain %>
 <% end -%>


### PR DESCRIPTION
set ONBOOT to diable the interface instead of removing ifcfg file and calling ifdown command

minor adjustments for /etc/sysconfig/network global settings to handle static default gateway when vlan tagging is enabled