### PR TITLE
ASM-6382 Centos 7 issues with dynamic networking and dhclient

### DIFF
--- a/lib/puppet/provider/service/systemd_network.rb
+++ b/lib/puppet/provider/service/systemd_network.rb
@@ -1,0 +1,28 @@
+# Manage Red Hat network service
+# Certain issues with network service can cause issues that need to be handled specially for centos/rhel 7
+# we clean up the dhclients for our interfaces if there's a client that exists after stopping/before starting the service
+# dhclients will be "orphaned" if network.service failed to start completely but some interfaces still came up anyway.
+# After that point, network.service will no longer "manage" those dhclients and they must be killed manually.
+# This can happen when network.service fails to start due to an ifcfg file existing for a nonexistent interface
+# at the time network service is started on boot of the vm, before puppet has a chance to clear those files.
+Puppet::Type.type(:service).provide :systemd_network, :parent => :systemd do
+
+  confine :osfamily => "RedHat"
+  confine :operatingsystemmajrelease => "7"
+
+  # Override how restart is done, so we can ensure the start/stop method is called, which will clean up our dhclients
+  def restart
+    self.stop
+    self.start
+  end
+
+  def stop
+    super
+    execute("pkill dhclient", :failonfail => false)
+  end
+
+  def start
+    execute("pkill dhclient", :failonfail => false)
+    super
+  end
+end

--- a/lib/puppet/type/clean_ifcfg.rb
+++ b/lib/puppet/type/clean_ifcfg.rb
@@ -1,0 +1,35 @@
+# This type is loosely based on Puppet's tidy resource. The tidy resource does not really support excluding filename patterns.
+Puppet::Type.newtype(:clean_ifcfg) do
+  desc "Deletes all ifcfg- files in /etc/sysconfig/network-scripts that do not have a name that matches our list to ignore"
+  newparam(:name)
+
+  newparam(:ignore) do
+    @doc = "List of interfaces that we don't want to leave ifcfg files for"
+    defaultto Facter["interfaces"].value
+    validate do |value|
+      raise ("ignore parameter must be a comma separated string of interface names") unless value.is_a?(String)
+      super(value)
+    end
+    munge do |value|
+      value.split(",").map(&:strip)
+    end
+  end
+
+  def generate
+    ifcfg_files = Dir["/etc/sysconfig/network-scripts/ifcfg-*"]
+    # ignore ifcfg-lo, as well as any ifcfg file for an interface we have said to ignore
+    ifcfg_files.reject! do |file|
+      file.end_with?("-lo") || self[:ignore].find{ |name| file.end_with?("-%s" % name)}
+    end
+    return if ifcfg_files.empty?
+    notice "Cleaning ifcfg files: %s" % ifcfg_files.to_s
+    ifcfg_files.collect {|path| mk_file_resource(path)}
+  end
+
+  # Reused from Puppet's tidy resource code
+  # Make a file resource to remove a given file.
+  def mk_file_resource(path)
+    # Force deletion, so directories actually get deleted.
+    Puppet::Type.type(:file).new :path => path, :ensure => :absent, :force => true
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,18 +31,27 @@ class network {
     }
   }
 
-  service { 'network':
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true
-  }
-
   # Disable NetworkManager - otherwise it may cause issues with default gateway and other routing rules
   service { 'NetworkManager':
     ensure     => 'stopped',
     enable     => false
   }
+
+  clean_ifcfg { 'clean_if_configs':
+    before => Service['network'],
+  }
+
+  # We use a custom service provider defined in this module for rhel/centos7 to eliminate an issue with "orphaned" dhclients
+    service { 'network':
+      ensure     => 'running',
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true,
+      provider   => $::operatingsystemmajrelease ? {
+        "7"     => "systemd_network",
+        default => undef
+      }
+    }
 
 } # class network
 


### PR DESCRIPTION
Whenever network.service would fail to start/restart, there would be
"orphaned" dhclients that were left running. Those clients would prevent
network.service to ever be able to start up correctly again until those
dhclients were manually renewed/stopped.
The failure would happen every time if a VM started with 2+ networks,
and then on the next reboot of the VM it had 1+ less networks.
ifcfg-ens* files would be left behind, which would cause the network
service to fail to start, which would orphan those dhclient processes
for the interfaces that successfully came up.
The fix for this is 2 parts:
1) Added a custom provider/type for removing any extra ifcfg files that
were not needed. There was an issue where could be ifcfg files
for the non-existant adapters (in our workflow, we get rid of an adapter
for the pxe network between reboots). This would cause an issue with
starting/restarting the network service correctly.

2)Added a custom service provider for restarting the network if we are
on rhel/centos7.  This just makes sure after stopping/before starting
the network service, all dhclient processes have been
released/terminated. This allows service network to start working again.