### PR TITLE
ASM-6715 Used eval_generate instead of generate in clean_ifcfg type

### DIFF
--- a/lib/puppet/type/clean_ifcfg.rb
+++ b/lib/puppet/type/clean_ifcfg.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:clean_ifcfg) do
     end
   end
 
-  def generate
+  def eval_generate
     ifcfg_files = Dir["/etc/sysconfig/network-scripts/ifcfg-*"]
     # ignore ifcfg-lo, as well as any ifcfg file for an interface we have said to ignore
     ifcfg_files.reject! do |file|


### PR DESCRIPTION
generate doesn't seem to keep ordering with the parent resource, which
causes an issue on when the ifcfg files are being deleted. We absolutely
need it to happen before restarting the network service. eval_generate
seems to help keep puppet ordering consistent again.