### PR TITLE
ASM-6829 work around CentOS 7.0 retaining network config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/fixtures/
 coverage/
 *.swp
 .vendor/
+*.iml

--- a/lib/puppet/provider/service/systemd_network.rb
+++ b/lib/puppet/provider/service/systemd_network.rb
@@ -16,13 +16,30 @@ Puppet::Type.type(:service).provide :systemd_network, :parent => :systemd do
     self.start
   end
 
-  def stop
-    super
+  def ifdown_all
+    # On certain RHEL / CentOS 7.0 ISOs some of the interfaces like
+    # em1 seem to keep their IP configuration settings after being
+    # reconfigured into a bonded interface until the network is
+    # restarted a second time. To work-around we ensure all interfaces
+    # are down
+    Facter["interfaces"].value.split(",").each do |iface|
+      execute("ifdown %s" % iface, :failonfail => false) unless iface == "lo"
+    end
+
+    # Workaround for case where dhclient gets left running if failures
+    # happen halfway through a "service network start" and cannot be
+    # managed after that due to those orphan processes.
     execute("pkill dhclient", :failonfail => false)
   end
 
+  def stop
+    super
+    ifdown_all
+  end
+
   def start
-    execute("pkill dhclient", :failonfail => false)
+    ifdown_all
     super
   end
 end
+


### PR DESCRIPTION
On CentOS / RHEL 7 when an interface with working networking settings
was reconfigured into a bonded network the original network settings
on the interface were retained until the network was restarted a
second time. During network restart this commit issues an ifdown on
all interfaces to work around that issue.