### PR TITLE
Revert "ASM-6829 work around CentOS 7.0 retaining network config"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ spec/fixtures/
 coverage/
 *.swp
 .vendor/
-*.iml


### PR DESCRIPTION
Reverts dell-asm/puppet-network#30