### PR TITLE
ASM-7474 give additional time for network start

### DIFF
--- a/templates/network.erb
+++ b/templates/network.erb
@@ -23,3 +23,4 @@ NETWORKING=yes
 <% end -%>
 <% if @nozeroconf %>NOZEROCONF=<%= @nozeroconf %>
 <% end -%>
+NETWORKDELAY=40


### PR DESCRIPTION
Deploying RHEL baremetal servers with LACP bonding configuration
seems to fail intermittently. The probability of this happening
is fairly low, but the OS may try to bring up the bonding interface
when the slaves are not up yet. Then the network start or restart
event fails with system log stating that the links are not ready
for the slave interfaces.

To resolve this, either the LINKDELAY opt on the bond ifcfg file or
the NETWORKDELAY opt on the network file has to be set. Ideally
this value should be set to 31 or greater. Best practice suggests
that 40 seconds is the best value to use. Initially the solution
implemented LINKDELAY, but it can prolong the network refresh
event to a few more minutes depending on the number of bonding
configurations and the vlan tagging. Since we do not need the
granular control on this, NETWORKDELAY is chosen to be used.

For the most part, this solution will not impact or be noticeable,
but it should reduce the intermittent failures caused by the
slave interfaces taking longer than ancitipated before starting
the bonding interface.