### PR TITLE
ASM-8219 fix pxe_cleanup hanging issue

### DIFF
--- a/manifests/pxe_cleanup.pp
+++ b/manifests/pxe_cleanup.pp
@@ -25,6 +25,7 @@ define network::pxe_cleanup (
   exec { "ifdown ${interface}":
     command => "ifdown ${interface}",
     path    => ['/usr/bin', '/usr/sbin', '/sbin'],
+    onlyif => "test `ifconfig | grep ${interface}` -n"
   }->
   file { "ifcfg-${interface}":
     ensure  => 'present',


### PR DESCRIPTION
This issue does not occur all the times, but pxe_cleanup resource
sometimes causes the puppet-agent process to fail because the
ifdown command hangs and fails eventually. This commit modifies
the target resource to call the ifdown command only if the PXE
interface is up and running. Otherwise, it will be ignored.