### PR TITLE
ASM-8219  Fix check for PXE interface

### DIFF
--- a/manifests/pxe_cleanup.pp
+++ b/manifests/pxe_cleanup.pp
@@ -25,7 +25,7 @@ define network::pxe_cleanup (
   exec { "ifdown ${interface}":
     command => "ifdown ${interface}",
     path    => ['/usr/bin', '/usr/sbin', '/sbin'],
-    onlyif => "test `ifconfig | grep ${interface}` -n"
+    onlyif => "test -z `ifconfig | grep ${interface}`"
   }->
   file { "ifcfg-${interface}":
     ensure  => 'present',


### PR DESCRIPTION
The `onlyif` was being evaluated incorrectly due to the `-n` at
the end