### PR TITLE
ASM-9020 Support Strings containing Ints and Ints

### DIFF
--- a/lib/puppet/parser/functions/get_seq_interface.rb
+++ b/lib/puppet/parser/functions/get_seq_interface.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
   newfunction(:get_seq_interface, :type => :rvalue) do |args|
-    seq = args[0]
+    seq = Integer(args[0])
     interfaces = lookupvar("interfaces")
 
     interfaces.split(",").reject { |ifn| ifn == "lo" }.sort[seq]


### PR DESCRIPTION
Previously in 6b5abd2bf the module was modified to specifically handle
integers as resource names.

This though is not a forwards compatible change as all resource names
must be strings:

    % puppet apply -e 'notify{1:}'
    ...Illegal title type at index 0. Expected String, got Integer

Thus these names have to be Strings if not now then in a few weeks when
we switch to Puppet 4.

This adjusts the get_seq_interface function to accept Strings as well as
Integers